### PR TITLE
upgrade debug to avoid nsp check failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "verb": ">= 0.2.6"
   },
   "dependencies": {
-    "debug": "^1.0.4",
+    "debug": "^2.2.0",
     "is-absolute": "^0.1.4"
   }
 }


### PR DESCRIPTION
old `debug` uses an insecure version of `ms`

```
┌───────────────┬─────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                            │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Name          │ ms                                                              │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Installed     │ 0.6.2                                                           │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=0.7.0                                                         │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Patched       │ >0.7.0                                                          │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ Path          │ mocha@0.0.0 > resolve-dep@0.5.3 > lookup-path@0.3.0 > debug@1.… │
├───────────────┼─────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/46                           │
└───────────────┴─────────────────────────────────────────────────────────────────┘
```

Plus!  The tests pass, and the debug output looks GREAT (imagine pretty colors below)

```
$ DEBUG=* npm test

> lookup-path@0.3.0 test /Volumes/alien/projects/forked/lookup-path
> mocha -R spec

  mocha:suite bail undefined +0ms
  mocha:suite enableTimeouts true +4ms
  mocha:suite bail undefined +7ms
  mocha:suite timeout 2000 +29ms
  mocha:suite retries -1 +0ms
  mocha:suite enableTimeouts true +0ms
  mocha:suite slow 75 +0ms
  mocha:suite bail undefined +0ms
  mocha:runnable timeout 2000 +1ms
  mocha:runnable enableTimeouts true +1ms
  mocha:runnable timeout 75 +0ms
  mocha:runnable timeout 2000 +0ms
  mocha:runnable enableTimeouts true +1ms
  mocha:runnable timeout 75 +0ms
  mocha:runnable timeout 2000 +0ms
  mocha:runnable enableTimeouts true +0ms
  mocha:runnable timeout 75 +0ms
  mocha:runnable timeout 2000 +0ms
  mocha:runnable enableTimeouts true +0ms
  mocha:runnable timeout 75 +0ms
  mocha:runner grep /.*/ +1ms
  mocha:runner globals ["DTRACE_NET_SERVER_CONNECTION","DTRACE_NET_STREAM_END","DTRACE_HTTP_SERVER_REQUEST","DTRACE_HTTP_SERVER_RESPONSE","DTRACE_HTTP_CLIENT_REQUEST","DTRACE_HTTP_CLIENT_RESPONSE","global","process","GLOBAL","root","Buffer","clearImmediate","clearInterval","clearTimeout","setImmediate","setInterval","setTimeout","console","before","after","beforeEach","afterEach","run","context","describe","xcontext","xdescribe","specify","it","xspecify","xit","XMLHttpRequest","Date","errno"] +1ms
  mocha:runner globals [] +1ms
  mocha:runner start +0ms

  mocha:runner run suite  +2ms

  mocha:runner run suite lookup +2ms
  lookup
    ✓ should lookup path
    ✓ should lookup path from the cwd
    ✓ should lookup path from the cwd
  lookup-path cannot find: tesksksks.js +8ms
    ✓ should return `null` when a path is not found.

  mocha:runner finished running +1ms

  4 passing (13ms)

  mocha:runner end +1ms
```
